### PR TITLE
Update zerocopy to latest released version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ range_map_vec = "0.1.0"
 static_assertions = "1.1"
 thiserror = "1.0"
 tracing = "0.1"
-zerocopy = "0.6"
+zerocopy = { version = "0.7.1", features = ["alloc","derive"] }

--- a/igvm/src/hv_defs.rs
+++ b/igvm/src/hv_defs.rs
@@ -11,6 +11,7 @@ use core::fmt::Debug;
 use open_enum::open_enum;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
+use zerocopy::FromZeroes;
 
 #[open_enum]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -178,7 +179,7 @@ impl From<Vtl> for u8 {
 
 /// An aligned u128 value.
 #[repr(C, align(16))]
-#[derive(Copy, Clone, PartialEq, Eq, AsBytes, FromBytes)]
+#[derive(Copy, Clone, PartialEq, Eq, AsBytes, FromBytes, FromZeroes)]
 pub struct AlignedU128([u8; 16]);
 
 impl AlignedU128 {
@@ -235,7 +236,7 @@ impl From<AlignedU128> for u128 {
 
 /// A `HV_REGISTER_VALUE` that represents virtual processor registers.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, AsBytes, FromBytes)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, AsBytes, FromBytes, FromZeroes)]
 pub struct HvRegisterValue(pub AlignedU128);
 
 impl HvRegisterValue {
@@ -299,7 +300,7 @@ impl From<u128> for HvRegisterValue {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, AsBytes, FromBytes)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, AsBytes, FromBytes, FromZeroes)]
 pub struct HvX64TableRegister {
     pub pad: [u16; 3],
     pub limit: u16,
@@ -319,7 +320,7 @@ impl From<HvRegisterValue> for HvX64TableRegister {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, AsBytes, FromBytes)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, AsBytes, FromBytes, FromZeroes)]
 pub struct HvX64SegmentRegister {
     pub base: u64,
     pub limit: u32,
@@ -348,7 +349,7 @@ macro_rules! registers {
         $(,)?
     }) => {
         #[open_enum]
-        #[derive(AsBytes, FromBytes, Debug, Clone, Copy, PartialEq, Eq)]
+        #[derive(AsBytes, FromBytes, FromZeroes, Debug, Clone, Copy, PartialEq, Eq)]
         #[repr(u32)]
         pub enum $name {
             $($variant = $value,)*

--- a/igvm/src/lib.rs
+++ b/igvm/src/lib.rs
@@ -30,6 +30,7 @@ use std::mem::size_of_val;
 use thiserror::Error;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
+use zerocopy::FromZeroes;
 
 pub mod hv_defs;
 pub mod page_table;
@@ -3671,7 +3672,7 @@ mod tests {
         };
         let expected_header = IGVM_VHS_PAGE_DATA {
             gpa,
-            ..FromBytes::new_zeroed()
+            ..FromZeroes::new_zeroed()
         };
         test_variable_header(
             IgvmRevision::V1,
@@ -3695,7 +3696,7 @@ mod tests {
         let expected_header = IGVM_VHS_PAGE_DATA {
             gpa,
             file_offset: file_data_offset,
-            ..FromBytes::new_zeroed()
+            ..FromZeroes::new_zeroed()
         };
         data.resize(PAGE_SIZE_4K as usize, 0);
         let expected_file_data = Some(data);
@@ -3721,7 +3722,7 @@ mod tests {
         let expected_header = IGVM_VHS_PAGE_DATA {
             gpa,
             file_offset: file_data_offset,
-            ..FromBytes::new_zeroed()
+            ..FromZeroes::new_zeroed()
         };
         let expected_file_data = Some(data);
         test_variable_header(
@@ -3957,7 +3958,7 @@ mod tests {
             number_of_bytes,
             compatibility_mask,
             flags,
-            ..FromBytes::new_zeroed()
+            ..FromZeroes::new_zeroed()
         };
 
         let header = IgvmDirectiveHeader::RequiredMemory {
@@ -3985,7 +3986,7 @@ mod tests {
             number_of_bytes,
             compatibility_mask,
             flags,
-            ..FromBytes::new_zeroed()
+            ..FromZeroes::new_zeroed()
         };
 
         let header = IgvmDirectiveHeader::RequiredMemory {

--- a/igvm/src/page_table.rs
+++ b/igvm/src/page_table.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use thiserror::Error;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
+use zerocopy::FromZeroes;
 
 const X64_CR4_LA57: u64 = 0x0000000000001000; // 5-level paging enabled
 
@@ -32,7 +33,7 @@ pub const X64_LARGE_PAGE_SIZE: u64 = 0x200000;
 /// Number of bytes in a 1GB page for X64.
 pub const X64_1GB_PAGE_SIZE: u64 = 0x40000000;
 
-#[derive(Copy, Clone, PartialEq, Eq, AsBytes, FromBytes)]
+#[derive(Copy, Clone, PartialEq, Eq, AsBytes, FromBytes, FromZeroes)]
 #[repr(transparent)]
 pub struct PageTableEntry {
     entry: u64,
@@ -122,7 +123,7 @@ impl PageTableEntry {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, AsBytes, FromBytes)]
+#[derive(Debug, Clone, PartialEq, Eq, AsBytes, FromBytes, FromZeroes)]
 pub struct PageTable {
     entries: [PageTableEntry; PAGE_TABLE_ENTRY_COUNT],
 }
@@ -556,6 +557,7 @@ mod tests {
     use crate::hv_defs::Vtl;
     use range_map_vec::RangeMap;
     use zerocopy::FromBytes;
+    use zerocopy::FromZeroes;
 
     #[derive(Debug, Clone)]
     struct PteInfo {

--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -5,6 +5,7 @@
 
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
+use zerocopy::FromZeroes;
 
 /// Virtual Event Injection
 /// Defined by the following union in C:
@@ -24,12 +25,12 @@ use zerocopy::FromBytes;
 /// } SEV_EVENT_INJECT_INFO, *PSEV_EVENT_INJECT_INFO;
 /// ```
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct SevEventInjectInfo(pub u64);
 
 /// A X64 selector register.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct SevSelector {
     pub selector: u16,
     pub attrib: u16,
@@ -39,7 +40,7 @@ pub struct SevSelector {
 
 /// A X64 XMM register.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct SevXmmRegister {
     low: u64,
     high: u64,
@@ -66,7 +67,7 @@ pub struct SevXmmRegister {
 /// };
 ///```
 #[bitfield_struct::bitfield(u64)]
-#[derive(AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct SevFeatures {
     pub snp: bool,
     pub vtom: bool,
@@ -104,12 +105,12 @@ pub struct SevFeatures {
 /// };
 ///```
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct SevVirtualInterruptControl(pub u64);
 
 /// SEV VMSA structure representing CPU state
 #[repr(C)]
-#[derive(Debug, Clone, Copy, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct SevVmsa {
     // Selector Info
     pub es: SevSelector,

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -105,6 +105,7 @@ use open_enum::open_enum;
 use static_assertions::const_assert_eq;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
+use zerocopy::FromZeroes;
 
 pub mod dt;
 
@@ -116,7 +117,7 @@ mod packed_nums {
 
 /// The version 1 fixed header that is at the start of every IGVM file.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IGVM_FIXED_HEADER {
     /// A u32 that must hold the value described by [`IGVM_MAGIC_VALUE`].
     pub magic: u32,
@@ -145,7 +146,7 @@ pub struct IGVM_FIXED_HEADER {
 #[cfg(feature = "unstable")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IGVM_FIXED_HEADER_V2 {
     /// A u32 that must hold the value described by [`IGVM_MAGIC_VALUE`].
     pub magic: u32,
@@ -203,7 +204,7 @@ pub const PAGE_SIZE_4K: u64 = 4096;
 #[cfg(feature = "unstable")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[open_enum]
-#[derive(AsBytes, FromBytes, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum IgvmArchitecture {
     /// Corresponds to x86-64 / AMD64, 64 bit x86.
@@ -224,9 +225,11 @@ pub enum IgvmArchitecture {
 /// The top bit of this type may be set to indicate a loader may safely ignore
 /// that structure.
 #[open_enum]
-#[derive(AsBytes, FromBytes, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum IgvmVariableHeaderType {
+    /// Invalid.
+    INVALID = 0x0,
     // These are IGVM_VHT_RANGE_PLATFORM structures.
     /// A supported platform structure described by
     /// [`IGVM_VHS_SUPPORTED_PLATFORM`].
@@ -340,7 +343,7 @@ pub const IGVM_VHT_RANGE_DIRECTIVE: core::ops::RangeInclusive<u32> = 0x301..=0x4
 /// The header describing each structure in the variable header section. Headers
 /// are aligned to 8 byte boundaries.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IGVM_VHS_VARIABLE_HEADER {
     /// The type of the header.
     pub typ: IgvmVariableHeaderType,
@@ -352,7 +355,7 @@ pub struct IGVM_VHS_VARIABLE_HEADER {
 /// Enum describing different isolation platforms for
 /// [`IGVM_VHS_SUPPORTED_PLATFORM`] structures.
 #[open_enum]
-#[derive(AsBytes, FromBytes, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(AsBytes, FromBytes, FromZeroes, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum IgvmPlatformType {
     /// Invalid platform type.
@@ -386,7 +389,7 @@ pub const IGVM_TDX_PLATFORM_VERSION: u16 = 0x1;
 /// prior to any other structures that refer to the compatibility mask that this
 /// structure defines.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_SUPPORTED_PLATFORM {
     /// A bitmask that is used in following variable header structures that
     /// correspond with this platform. Headers that have this corresponding bit
@@ -411,7 +414,7 @@ pub struct IGVM_VHS_SUPPORTED_PLATFORM {
 /// This structure defines the guest policy that is isolation architecture
 /// dependent.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_GUEST_POLICY {
     /// The specified policy which is isolation architecture dependent.
     ///
@@ -430,7 +433,7 @@ pub struct IGVM_VHS_GUEST_POLICY {
 /// For now, this matches the definition in Section 4.3 Guest Policy of the AMD
 /// SEV-SNP specification.
 #[bitfield(u64)]
-#[derive(AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct SnpPolicy {
     pub abi_minor: u8,
     pub abi_major: u8,
@@ -450,7 +453,7 @@ pub struct SnpPolicy {
 
 /// The Intel TDX policy used in [`IGVM_VHS_GUEST_POLICY::policy`].
 #[bitfield(u64)]
-#[derive(AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct TdxPolicy {
     #[bits(1)]
     pub debug_allowed: u8,
@@ -484,7 +487,7 @@ pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_GDTR: u8 = 0x4;
 /// # Architecture
 /// X64 only.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_RELOCATABLE_REGION {
     /// Compatibility mask.
     pub compatibility_mask: u32,
@@ -583,7 +586,7 @@ pub struct IGVM_VHS_RELOCATABLE_REGION {
 /// # Architecture
 /// X64 only.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_PAGE_TABLE_RELOCATION {
     /// Compatibility mask.
     pub compatibility_mask: u32,
@@ -610,7 +613,7 @@ pub struct IGVM_VHS_PAGE_TABLE_RELOCATION {
 /// The paramter area is imported into the guest address space via a
 /// [`IGVM_VHS_PARAMETER_INSERT`] structure.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_PARAMETER_AREA {
     /// The size of the parameter region, in bytes. This must be page aligned.
     pub number_of_bytes: u64,
@@ -628,7 +631,7 @@ pub struct IGVM_VHS_PARAMETER_AREA {
 /// Page data types that describe the type of import for
 /// [`IGVM_VHS_PAGE_DATA`].
 #[open_enum]
-#[derive(AsBytes, FromBytes, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum IgvmPageDataType {
     /// Normal page data.
@@ -652,7 +655,7 @@ impl Default for IgvmPageDataType {
 
 /// Flags for [`IGVM_VHS_PAGE_DATA`] structures.
 #[bitfield(u32)]
-#[derive(AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IgvmPageDataFlags {
     /// This page data is a 2MB page. If this is set, the
     /// [`IGVM_VHS_PAGE_DATA::gpa`] field must be aligned to 2MB.
@@ -680,7 +683,7 @@ pub struct IgvmPageDataFlags {
 /// | TDX partitioning enabled  | Highest VTL only       |
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_PAGE_DATA {
     /// The guest physical address at which this page data should be loaded; it
     /// must be aligned to a page size boundary.
@@ -708,7 +711,7 @@ pub struct IGVM_VHS_PAGE_DATA {
 /// This structure controls the insertion of a parameter area into the guest
 /// address space.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_PARAMETER_INSERT {
     /// The guest physical address where this parameter area should be imported
     /// into the guest address space. It must be page size aligned.
@@ -739,7 +742,7 @@ pub struct IGVM_VHS_PARAMETER_INSERT {
 /// guests must perform validation on the values written into parameter areas. A
 /// malicious or buggy loader may write any values.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_PARAMETER {
     /// The paramter area index for this parameter.
     pub parameter_area_index: u32,
@@ -759,7 +762,7 @@ pub struct IGVM_VHS_PARAMETER {
 ///
 /// Note that this structure is not aligned to 8 bytes.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_VP_CONTEXT {
     /// The guest physical address where the VP context data should be
     /// deposited, if required.
@@ -795,7 +798,7 @@ pub struct IGVM_VHS_VP_CONTEXT {
 /// The format of the data written by the guest into the error ranges to be read
 /// by the host are outside of the scope of this specification.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_ERROR_RANGE {
     /// The guest physical address that this error range starts at. It must be
     /// page aligned.
@@ -811,7 +814,7 @@ pub struct IGVM_VHS_ERROR_RANGE {
 /// The format consists of a [`VbsVpContextHeader`] followed by a
 /// `register_count` of [`VbsVpContextRegister`].
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct VbsVpContextHeader {
     /// The number of registers in this VP context.
     pub register_count: u32,
@@ -820,7 +823,7 @@ pub struct VbsVpContextHeader {
 /// The registers associated with a VBS [`IGVM_VHS_VP_CONTEXT`] structure in the
 /// file data section.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, AsBytes, FromBytes)]
+#[derive(Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct VbsVpContextRegister {
     /// The VTL to import this register to.
     pub vtl: u8,
@@ -845,7 +848,7 @@ const_assert_eq!(size_of::<VbsVpContextRegister>(), 0x20);
 /// Note that the guest cannot rely on memory being present at this location at
 /// runtime, as a malicious host may choose to ignore this header.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_REQUIRED_MEMORY {
     /// The base guest physical address for this range. This must be page
     /// aligned.
@@ -862,7 +865,7 @@ pub struct IGVM_VHS_REQUIRED_MEMORY {
 
 /// Flags for [`IGVM_VHS_REQUIRED_MEMORY`].
 #[bitfield(u32)]
-#[derive(AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct RequiredMemoryFlags {
     pub vtl2_protectable: bool,
     #[bits(31)]
@@ -871,7 +874,7 @@ pub struct RequiredMemoryFlags {
 
 /// A structure describing memory via a range of pages.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_MEMORY_RANGE {
     /// The base guest physical page number for this range.
     pub starting_gpa_page_number: u64,
@@ -887,7 +890,7 @@ pub struct IGVM_VHS_MEMORY_RANGE {
 /// [`IgvmVariableHeaderType::IGVM_VHT_DEVICE_TREE`] parameter should be used
 /// instead.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_MMIO_RANGES {
     /// The mmio ranges for the guest. Note that this structure can only report
     /// two ranges, regardless of how many are available to the guest.
@@ -896,7 +899,7 @@ pub struct IGVM_VHS_MMIO_RANGES {
 
 /// Signature for SNP ID block. See the corresponding PSP definitions.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_SNP_ID_BLOCK_SIGNATURE {
     /// r_comp
     pub r_comp: [u8; 72],
@@ -906,7 +909,7 @@ pub struct IGVM_VHS_SNP_ID_BLOCK_SIGNATURE {
 
 /// Public key for SNP ID block. See the corresponding PSP definitions.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_SNP_ID_BLOCK_PUBLIC_KEY {
     /// curve
     pub curve: u32,
@@ -928,7 +931,7 @@ pub struct IGVM_VHS_SNP_ID_BLOCK_PUBLIC_KEY {
 ///
 /// TODO: doc links for fields to SNP spec.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IGVM_VHS_SNP_ID_BLOCK {
     /// Compatibility mask.
     pub compatibility_mask: u32,
@@ -965,7 +968,7 @@ pub struct IGVM_VHS_SNP_ID_BLOCK {
 ///
 /// TODO: doc fields
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IGVM_VHS_VBS_MEASUREMENT {
     /// Compatibility mask
     pub compatibility_mask: u32,
@@ -993,7 +996,7 @@ pub struct IGVM_VHS_VBS_MEASUREMENT {
 
 /// The type of memory described by a memory map entry or device tree node.
 #[open_enum]
-#[derive(AsBytes, FromBytes, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum MemoryMapEntryType {
     /// Normal memory.
@@ -1021,7 +1024,7 @@ impl Default for MemoryMapEntryType {
 /// A well-behaved loader will report these in sorted order, with a final entry
 /// with `number_of_pages` with zero signifying the last entry.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct IGVM_VHS_MEMORY_MAP_ENTRY {
     /// The starting gpa page number for this range of memory.
     pub starting_gpa_page_number: u64,
@@ -1037,18 +1040,22 @@ pub struct IGVM_VHS_MEMORY_MAP_ENTRY {
 
 /// The signature algorithm to use for VBS digest.
 #[open_enum]
-#[derive(AsBytes, FromBytes, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(AsBytes, FromBytes, FromZeroes, Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum VbsDigestAlgorithm {
+    /// Invalid.
+    INVALID = 0x0,
     /// SHA256.
     SHA256 = 0x1,
 }
 
 /// The signature algorithm to use for VBS measurement.
 #[open_enum]
-#[derive(AsBytes, FromBytes, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(AsBytes, FromBytes, FromZeroes, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
 pub enum VbsSigningAlgorithm {
+    /// Invalid.
+    INVALID = 0x0,
     /// ECDSA P384.
     ECDSA_P384 = 0x1,
 }


### PR DESCRIPTION
This update is necessary to work with latest cloud-hypervisor. Cloud-hypervisor uses latest version of zerocopy that gives build issues with the older version of zerocopy used in igvm crate.