### PR TITLE
Cargo.toml: Bump open-enum to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 bitfield-struct = "0.5"
 crc32fast = { version = "1.3.2", default-features = false }
 hex = "0.4"
-open-enum = "0.3.0"
+open-enum = "0.4.1"
 range_map_vec = "0.1.0"
 static_assertions = "1.1"
 thiserror = "1.0"


### PR DESCRIPTION
Fixes #2 