### PR TITLE
igvm_defs: define flags property for device tree

### DIFF
--- a/igvm_defs/src/dt.rs
+++ b/igvm_defs/src/dt.rs
@@ -10,6 +10,13 @@
 /// the type defined by [`crate::MemoryMapEntryType`].
 pub const IGVM_DT_IGVM_TYPE_PROPERTY: &str = "microsoft,igvm-type";
 
+/// The property name to describe IGVM specific flags on a DT node.
+///
+/// A DT memory node is extended with the IGVM flags property to describe the
+/// IGVM memory flags for that node. This is encoded as a u32 value containing
+/// the type defined by [`crate::MemoryMapEntryFlags`].
+pub const IGVM_DT_IGVM_FLAGS_PROPERTY: &str = "microsoft,igvm-flags";
+
 /// The property name to describe VTL specific information on a DT node.
 ///
 /// A DT VMBUS root node is extended with the VTL property to describe the VTL


### PR DESCRIPTION
Add the flags type for memory entries that are exposed via device tree, to match type. Finishes #9. 