### PR TITLE
workspace: fix default workspace zerocopy feature pulling in alloc on no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ range_map_vec = "0.1.0"
 static_assertions = "1.1"
 thiserror = "1.0"
 tracing = "0.1"
-zerocopy = { version = "0.7.1", features = ["alloc","derive"] }
+zerocopy = { version = "0.7.1", features = ["derive"] }


### PR DESCRIPTION
Zerocopy dependency in the root of the workspace is causing alloc to be pulled in on no_std builds. Remove it to allow igvm_defs to be use in no_std without alloc. 