### PR TITLE
igvm_defs: define the shared bit for IgvmPageDataFlags

### DIFF
--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -207,7 +207,7 @@ pub struct SevVmsa {
     // SYSENTER config registers
     pub sysenter_cs: u64,
     pub sysenter_esp: u64,
-    pub sysenter_epi: u64,
+    pub sysenter_eip: u64,
 
     // CR2
     pub cr2: u64,

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -662,9 +662,25 @@ pub struct IgvmPageDataFlags {
     pub is_2mb_page: bool,
     /// This page data should be imported as unmeasured.
     pub unmeasured: bool,
+    /// This page data should be imported as assigned but host visible. The page
+    /// contents must be preserved, but are not part of the launch measurement.
+    ///
+    /// NOTE: This is technically unstable, but macro errors prevent us from
+    /// hiding this definition.
+    pub shared: bool,
     /// Reserved.
-    #[bits(30)]
+    #[bits(29)]
     pub reserved: u32,
+    // TODO: Macro errors prevent us from using the desired definition below.
+    // bitfield_struct issue?
+    // #[cfg(feature = "unstable")]
+    // #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    // pub shared: bool,
+    // /// Reserved.
+    // #[cfg_attr(feature = "unstable", bits(29))]
+    // pub reserved: u32,
+    // #[cfg_attr(not(feature = "unstable"), bits(30))]
+    // pub reserved: u32,
 }
 
 /// This structure describes a page of data that should be loaded into the guest


### PR DESCRIPTION
This tells the host loader to import the page as shared, which makes the data available to the guest but not part of the launch measurement, assuming the host loader is well behaved. 

Also fix a typo in snp_defs. 