### PR TITLE
igvm: Fix visibility of SevXmmRegister members

### DIFF
--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -42,8 +42,8 @@ pub struct SevSelector {
 #[repr(C)]
 #[derive(Debug, Clone, Copy, AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct SevXmmRegister {
-    low: u64,
-    high: u64,
+    pub low: u64,
+    pub high: u64,
 }
 
 /// SEV feature information.


### PR DESCRIPTION
The visibility of all members in the structures defined in snp_defs.rs should be public allowing direct access to the fields within the structures. This was not true for `SevXmmRegister`.

This commit makes the fields in the structure public.