### PR TITLE
igvm, igvm_defs: Move to SPDX License identifier

### DIFF
--- a/igvm/src/hv_defs.rs
+++ b/igvm/src/hv_defs.rs
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 //! A subset of the Microsoft hypervisor definitions used by the igvm crate.
 //!

--- a/igvm/src/lib.rs
+++ b/igvm/src/lib.rs
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 //! Provides a Rust implementation of an Independent Guest Virtual Machine
 //! (IGVM) file format parser, with the specification defined by the

--- a/igvm/src/page_table.rs
+++ b/igvm/src/page_table.rs
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 //! Methods to construct page tables.
 

--- a/igvm/src/parsing.rs
+++ b/igvm/src/parsing.rs
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 //! Trait to help parse binary types.
 

--- a/igvm/src/registers.rs
+++ b/igvm/src/registers.rs
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 //! Register types used by the IGVM file format.
 

--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 //! AMD SEV-SNP specific definitions.
 

--- a/igvm_defs/src/dt.rs
+++ b/igvm_defs/src/dt.rs
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 //! Device tree (DT) specific information related to IGVM.
 

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 //! This crate provides the definitions for the Independent Guest Virtual
 //! Machine (IGVM) file format.


### PR DESCRIPTION
Fixes #23