### PR TITLE
deps: update zerocopy due to previous release being yanked

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ range_map_vec = "0.1.0"
 static_assertions = "1.1"
 thiserror = "1.0"
 tracing = "0.1"
-zerocopy = { version = "0.7.1", features = ["derive"] }
+zerocopy = { version = "0.7.32", features = ["derive"] }


### PR DESCRIPTION
Update to the latest version not yanked so we can publish to crates.io. 