### PR TITLE
igvm_defs: fix incorrect revert of IgvmPageDataFlags instead of MemoryMapEntryFlags

### DIFF
--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -208,7 +208,7 @@ pub struct SevVmsa {
     // SYSENTER config registers
     pub sysenter_cs: u64,
     pub sysenter_esp: u64,
-    pub sysenter_epi: u64,
+    pub sysenter_eip: u64,
 
     // CR2
     pub cr2: u64,

--- a/igvm_defs/src/dt.rs
+++ b/igvm_defs/src/dt.rs
@@ -11,13 +11,6 @@
 /// the type defined by [`crate::MemoryMapEntryType`].
 pub const IGVM_DT_IGVM_TYPE_PROPERTY: &str = "microsoft,igvm-type";
 
-/// The property name to describe IGVM specific flags on a DT node.
-///
-/// A DT memory node is extended with the IGVM flags property to describe the
-/// IGVM memory flags for that node. This is encoded as a u32 value containing
-/// the type defined by [`crate::MemoryMapEntryFlags`].
-pub const IGVM_DT_IGVM_FLAGS_PROPERTY: &str = "microsoft,igvm-flags";
-
 /// The property name to describe VTL specific information on a DT node.
 ///
 /// A DT VMBUS root node is extended with the VTL property to describe the VTL

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -684,9 +684,25 @@ pub struct IgvmPageDataFlags {
     pub is_2mb_page: bool,
     /// This page data should be imported as unmeasured.
     pub unmeasured: bool,
+    /// This page data should be imported as assigned but host visible. The page
+    /// contents must be preserved, but are not part of the launch measurement.
+    ///
+    /// NOTE: This is technically unstable, but macro errors prevent us from
+    /// hiding this definition.
+    pub shared: bool,
     /// Reserved.
-    #[bits(30)]
+    #[bits(29)]
     pub reserved: u32,
+    // TODO: Macro errors prevent us from using the desired definition below.
+    // bitfield_struct issue?
+    // #[cfg(feature = "unstable")]
+    // #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    // pub shared: bool,
+    // /// Reserved.
+    // #[cfg_attr(feature = "unstable", bits(29))]
+    // pub reserved: u32,
+    // #[cfg_attr(not(feature = "unstable"), bits(30))]
+    // pub reserved: u32,
 }
 
 /// This structure describes a page of data that should be loaded into the guest

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -1055,17 +1055,6 @@ impl Default for MemoryMapEntryType {
     }
 }
 
-/// Flags associated with a memory map entry.
-#[bitfield(u16)]
-#[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
-pub struct MemoryMapEntryFlags {
-    /// Memory is in the shared state, and an explicit call must be made to
-    /// change it to the private state before it can be accepted and used.
-    pub is_shared: bool,
-    #[bits(15)]
-    pub reserved: u16,
-}
-
 /// The structure deposited by the loader for memory map entries for
 /// [`IgvmVariableHeaderType::IGVM_VHT_MEMORY_MAP`] that describe memory
 /// available to the guest.
@@ -1082,7 +1071,7 @@ pub struct IGVM_VHS_MEMORY_MAP_ENTRY {
     /// The type of memory this entry represents.
     pub entry_type: MemoryMapEntryType,
     /// Flags about this memory entry.
-    pub flags: MemoryMapEntryFlags,
+    pub flags: u16,
     /// Reserved.
     pub reserved: u32,
 }


### PR DESCRIPTION
PR #17 meant to revert PR #8 and PR #11 but instead reverted PR #14 incorrectly. 

Fix this by reapplying PR #14 and correctly reverting PR #8 and PR #11. 