### PR TITLE
igvm_c: Fix linker issues with sample and tests and clean up output

### DIFF
--- a/igvm_c/Makefile
+++ b/igvm_c/Makefile
@@ -39,10 +39,10 @@ include/igvm.h: $(RUST_SOURCE)
 	cbindgen -q -c $(API_DIR)/cbindgen_igvm_defs.toml $(IGVM_DIR)/igvm_defs -o "$(API_DIR)/include/igvm_defs.h"
 
 $(TARGET_PATH)/dump_igvm: $(API_DIR)/include/igvm.h $(API_DIR)/sample/dump_igvm.c $(TARGET_PATH)/libigvm.a
-	cc -g3 -O0 -I $(API_DIR) -L $(TARGET_PATH) -o $@ $^ -ligvm -lcunit
+	cc -g3 -O0 -I $(API_DIR) -L $(TARGET_PATH) -o $@ $^ -ligvm -ldl -pthread -lm -lutil -lrt
 
 $(TARGET_PATH)/igvm_test: $(API_DIR)/include/igvm.h $(API_DIR)/tests/igvm_test.c $(TARGET_PATH)/libigvm.a
-	cc -g3 -O0 -I $(API_DIR) -L $(TARGET_PATH) -o $@ $^ -ligvm -lcunit
+	cc -g3 -O0 -I $(API_DIR) -L $(TARGET_PATH) -o $@ $^ -ligvm -lcunit -ldl -pthread -lm -lutil -lrt
 
 $(TARGET_PATH)/igvm.bin: $(TARGET_PATH)/test_data
 	$(TARGET_PATH)/test_data $(TARGET_PATH)/igvm.bin

--- a/igvm_c/Makefile
+++ b/igvm_c/Makefile
@@ -35,8 +35,8 @@ $(TARGET_PATH)/test_data:
 	$(CARGO) build --manifest-path=$(IGVM_DIR)/igvm_c/test_data/Cargo.toml
 
 include/igvm.h: $(RUST_SOURCE)
-	cbindgen -c $(API_DIR)/cbindgen_igvm.toml $(IGVM_DIR)/igvm -o "$(API_DIR)/include/igvm.h"
-	cbindgen -c $(API_DIR)/cbindgen_igvm_defs.toml $(IGVM_DIR)/igvm_defs -o "$(API_DIR)/include/igvm_defs.h"
+	cbindgen -q -c $(API_DIR)/cbindgen_igvm.toml $(IGVM_DIR)/igvm -o "$(API_DIR)/include/igvm.h"
+	cbindgen -q -c $(API_DIR)/cbindgen_igvm_defs.toml $(IGVM_DIR)/igvm_defs -o "$(API_DIR)/include/igvm_defs.h"
 
 $(TARGET_PATH)/dump_igvm: $(API_DIR)/include/igvm.h $(API_DIR)/sample/dump_igvm.c $(TARGET_PATH)/libigvm.a
 	cc -g3 -O0 -I $(API_DIR) -L $(TARGET_PATH) -o $@ $^ -ligvm -lcunit

--- a/igvm_c/README.md
+++ b/igvm_c/README.md
@@ -45,6 +45,21 @@ exported C functions.
 The file `igvm.h` includes `igvm_defs.h` so only this file needs to be included
 in C projects source files.
 
+## Installing
+Once built, the library can be installed with:
+
+```bash
+make -f Makefile install
+```
+
+By default, the library will be installed into `/usr` which will require root
+privileges. Alternatively, the library can be installed in a different location
+by setting `PREFIX`:
+
+```bash
+PREFIX=/path/to/installation make -f Makefile install
+```
+
 ## Sample application
 The C API build generates a test application named `dump_igvm`. This application
 can take the path of a binary IGVM file as a parameter and will use the C API to


### PR DESCRIPTION
It was reported on https://github.com/coconut-svsm/svsm/pull/237 that on certain environments, the C unit tests and sample fail to build due to missing library dependencies. Also, the status of the build is hard to determine due to the amount of warnings generated by cbindgen. See the comment thread in that PR from @cclaudio.

The required list of libraries can be determined with the following command:

```
cargo rustc --verbose --features "igvm-c" --manifest-path=igvm/Cargo.toml -- --print=native-static-libs
```
This PR updates the Makefile to reflect the output of this command. In addition, the cbindgen `-q` flag is used to suppress warnings - it would be good to fix the warnings but this would require the generation of redundant additional output in the header files which is not ideal.

Finally, add a section to the README to describe how to install the library.