### PR TITLE
igvm/snp_defs: do not mark C code as doctests

### DIFF
--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -10,7 +10,7 @@ use zerocopy::FromZeroes;
 
 /// Virtual Event Injection
 /// Defined by the following union in C:
-/// ```ignore
+/// ```C
 /// typedef union _SEV_EVENT_INJECT_INFO
 /// {
 ///     UINT64 AsUINT64;
@@ -49,7 +49,7 @@ pub struct SevXmmRegister {
 
 /// SEV feature information.
 /// Defined by the following union in C:
-///```ignore
+///```C
 /// union
 /// {
 ///     UINT64  SevFeatures;
@@ -84,7 +84,7 @@ pub struct SevFeatures {
 
 /// SEV Virtual interrupt control
 /// Defined by the following union in C:
-///```ignore
+///```C
 /// union
 /// {
 ///     UINT64  VIntrCtrl;


### PR DESCRIPTION
There is some C code that is currently set up as ignored doctests. These will show up when running `cargo test`. Simply declare them as non-Rust code.