### PR TITLE
workspace: disable default features for `hex`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ igvm = { path = "igvm", version = "0.1.6" }
 anyhow = "1.0"
 bitfield-struct = "0.5"
 crc32fast = { version = "1.3.2", default-features = false }
-hex = "0.4"
+hex = { version = "0.4", default-features = false }
 open-enum = "0.4.1"
 range_map_vec = "0.1.0"
 static_assertions = "1.1"

--- a/igvm/Cargo.toml
+++ b/igvm/Cargo.toml
@@ -31,7 +31,7 @@ igvm_defs = { workspace = true, features = ["unstable"] }
 bitfield-struct.workspace = true
 range_map_vec.workspace = true
 crc32fast.workspace = true
-hex.workspace = true
+hex = { workspace = true, features = ["alloc"] }
 open-enum.workspace = true
 thiserror.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
`hex` by default is built for std. If other no_std crates include `igvm` as a dependency, during the build Cargo enables features incrementally, thus leaving "std" enabled.

Let's disable `hex` default features, so if other no_std crates include `igvm` as a dependency they can be built without errors.