### PR TITLE
release: release version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ members = [
 ]
 
 [workspace.dependencies]
-igvm_defs = { path = "igvm_defs", version = "0.1.9" }
-igvm = { path = "igvm", version = "0.1.9" }
+igvm_defs = { path = "igvm_defs", version = "0.2.0" }
+igvm = { path = "igvm", version = "0.2.0" }
 
 anyhow = "1.0"
 bitfield-struct = "0.5"

--- a/igvm/Cargo.toml
+++ b/igvm/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "igvm"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 description = "The igvm crate is an implementation of a parser for the Independent Guest Virtual Machine (IGVM) file format."
 license = "MIT"

--- a/igvm_defs/Cargo.toml
+++ b/igvm_defs/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "igvm_defs"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 description = "The igvm_defs crate is the specification for the Independent Guest Virtual Machine (IGVM) file format."
 license = "MIT"


### PR DESCRIPTION
Rev the minor version as this is a breaking change. The breaking change is due to #44 changing the function signature of `write_binary_data` to support file data deduplication. 