### PR TITLE
snp_defs: add missing fields for `SevFeatures`

### DIFF
--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -63,7 +63,9 @@ pub struct SevXmmRegister {
 ///         UINT64  SevFeatureDebugSwap             : 1;
 ///         UINT64  SevFeaturePreventHostIBS        : 1;
 ///         UINT64  SevFeatureSNPBTBIsolation       : 1;
-///         UINT64  SevFeatureResrved2              : 56;
+///         UINT64  SevFeatureResrved               : 6;
+///         UINT64  SevFeatureVmsaRegProt           : 1;
+///         UINT64  SevFeatureResrved2              : 49;
 ///     };
 /// };
 ///```
@@ -78,8 +80,11 @@ pub struct SevFeatures {
     pub debug_swap: bool,
     pub prevent_host_ibs: bool,
     pub snp_btb_isolation: bool,
-    #[bits(56)]
-    _unused: u64,
+    #[bits(6)]
+    _reserved: u8,
+    pub vmsa_reg_protection: bool,
+    #[bits(49)]
+    _reserved2: u64,
 }
 
 /// SEV Virtual interrupt control

--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -63,7 +63,9 @@ pub struct SevXmmRegister {
 ///         UINT64  SevFeatureDebugSwap             : 1;
 ///         UINT64  SevFeaturePreventHostIBS        : 1;
 ///         UINT64  SevFeatureSNPBTBIsolation       : 1;
-///         UINT64  SevFeatureResrved               : 6;
+///         UINT64  SevFeatureResrved0              : 1;
+///         UINT64  SevFeatureSecureTscEn           : 1;
+///         UINT64  SevFeatureResrved1              : 4;
 ///         UINT64  SevFeatureVmsaRegProt           : 1;
 ///         UINT64  SevFeatureSmtProtection         : 1;
 ///         UINT64  SevFeatureResrved2              : 48;
@@ -81,8 +83,11 @@ pub struct SevFeatures {
     pub debug_swap: bool,
     pub prevent_host_ibs: bool,
     pub snp_btb_isolation: bool,
-    #[bits(6)]
-    _reserved: u8,
+    #[bits(1)]
+    _reserved0: u8,
+    pub secure_tsc: bool,
+    #[bits(4)]
+    _reserved1: u8,
     pub vmsa_reg_protection: bool,
     pub smt_protection: bool,
     #[bits(48)]

--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -65,7 +65,8 @@ pub struct SevXmmRegister {
 ///         UINT64  SevFeatureSNPBTBIsolation       : 1;
 ///         UINT64  SevFeatureResrved               : 6;
 ///         UINT64  SevFeatureVmsaRegProt           : 1;
-///         UINT64  SevFeatureResrved2              : 49;
+///         UINT64  SevFeatureSmtProtection         : 1;
+///         UINT64  SevFeatureResrved2              : 48;
 ///     };
 /// };
 ///```
@@ -83,7 +84,8 @@ pub struct SevFeatures {
     #[bits(6)]
     _reserved: u8,
     pub vmsa_reg_protection: bool,
-    #[bits(49)]
+    pub smt_protection: bool,
+    #[bits(48)]
     _reserved2: u64,
 }
 

--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -63,7 +63,7 @@ pub struct SevXmmRegister {
 ///         UINT64  SevFeatureDebugSwap             : 1;
 ///         UINT64  SevFeaturePreventHostIBS        : 1;
 ///         UINT64  SevFeatureSNPBTBIsolation       : 1;
-///         UINT64  SevFeatureResrved0              : 1;
+///         UINT64  SevFeatureVpmlSSS               : 1;
 ///         UINT64  SevFeatureSecureTscEn           : 1;
 ///         UINT64  SevFeatureResrved1              : 4;
 ///         UINT64  SevFeatureVmsaRegProt           : 1;
@@ -83,8 +83,7 @@ pub struct SevFeatures {
     pub debug_swap: bool,
     pub prevent_host_ibs: bool,
     pub snp_btb_isolation: bool,
-    #[bits(1)]
-    _reserved0: u8,
+    pub vmpl_supervisor_shadow_stack: bool,
     pub secure_tsc: bool,
     #[bits(4)]
     _reserved1: u8,


### PR DESCRIPTION
Add several missing bits for `SevFeatures`:
* bit 8: VMPL Supervisor Shadow Stack (VmplSSS).
* bit 9: Secure TSC (SecureTscEn).
* bit 14: VMSA Register Protection (VmsaRegProt).
* bit 15: SMT Protection (SmtProtection).