### PR TITLE
deps, release: rev range_map_vec to 0.2.0, rev overall versions to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ members = [
 ]
 
 [workspace.dependencies]
-igvm_defs = { path = "igvm_defs", version = "0.2.1" }
-igvm = { path = "igvm", version = "0.2.1" }
+igvm_defs = { path = "igvm_defs", version = "0.3.0" }
+igvm = { path = "igvm", version = "0.3.0" }
 
 anyhow = "1.0"
 bitfield-struct = "0.5"
 crc32fast = { version = "1.3.2", default-features = false }
 hex = { version = "0.4", default-features = false }
 open-enum = "0.4.1"
-range_map_vec = "0.1.0"
+range_map_vec = "0.2.0"
 static_assertions = "1.1"
 thiserror = "1.0"
 tracing = "0.1"

--- a/igvm/Cargo.toml
+++ b/igvm/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "igvm"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "The igvm crate is an implementation of a parser for the Independent Guest Virtual Machine (IGVM) file format."
 license = "MIT"

--- a/igvm_defs/Cargo.toml
+++ b/igvm_defs/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "igvm_defs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "The igvm_defs crate is the specification for the Independent Guest Virtual Machine (IGVM) file format."
 license = "MIT"


### PR DESCRIPTION
Pickup the latest version of range_map_vec that implements `.iter()` correctly to DoubleEndedIterator. 

Since we return this type in the igvm crate from a public method, this is unfortunately a breaking change. Rev the igvm crates version to 0.3.0. 