### PR TITLE
Add support for aarch64 relocations.

### DIFF
--- a/igvm/src/lib.rs
+++ b/igvm/src/lib.rs
@@ -2428,13 +2428,6 @@ impl IgvmFile {
                     vp_index,
                     vtl,
                 } => {
-                    if revision.arch() != Arch::X64 {
-                        return Err(Error::InvalidHeaderArch {
-                            arch: revision.arch(),
-                            header_type: "PageTableRelocationRegion".into(),
-                        });
-                    }
-
                     // Header can be only specified once per compatibility mask
                     if compatibility_mask & page_table_masks != 0 {
                         return Err(Error::MultiplePageTableRelocationHeaders);
@@ -2467,13 +2460,6 @@ impl IgvmFile {
                     vp_index,
                     vtl,
                 } => {
-                    if revision.arch() != Arch::X64 {
-                        return Err(Error::InvalidHeaderArch {
-                            arch: revision.arch(),
-                            header_type: "RelocatableRegion".into(),
-                        });
-                    }
-
                     check_region_overlap(
                         *compatibility_mask,
                         *relocation_region_gpa,

--- a/igvm/src/lib.rs
+++ b/igvm/src/lib.rs
@@ -2428,6 +2428,13 @@ impl IgvmFile {
                     vp_index,
                     vtl,
                 } => {
+                    if !matches!(revision.arch(), Arch::X64 | Arch::AArch64) {
+                        return Err(Error::InvalidHeaderArch {
+                            arch: revision.arch(),
+                            header_type: "PageTableRelocationRegion".into(),
+                        });
+                    }
+
                     // Header can be only specified once per compatibility mask
                     if compatibility_mask & page_table_masks != 0 {
                         return Err(Error::MultiplePageTableRelocationHeaders);
@@ -2460,6 +2467,13 @@ impl IgvmFile {
                     vp_index,
                     vtl,
                 } => {
+                    if !matches!(revision.arch(), Arch::X64 | Arch::AArch64) {
+                        return Err(Error::InvalidHeaderArch {
+                            arch: revision.arch(),
+                            header_type: "RelocatableRegion".into(),
+                        });
+                    }
+
                     check_region_overlap(
                         *compatibility_mask,
                         *relocation_region_gpa,

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -485,6 +485,7 @@ pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_START_ADDRESS: u8 = 0x2;
 /// region was relocated. This is supported on X64 only.
 pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_GDTR: u8 = 0x4;
 
+/// Legacy name for ['IGVM_VHF_RELOCATABLE_REGION_APPLY_START_ADDRESS']
 pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_RIP: u8 =
     IGVM_VHF_RELOCATABLE_REGION_APPLY_START_ADDRESS;
 
@@ -609,8 +610,8 @@ pub struct IGVM_VHS_PAGE_TABLE_RELOCATION {
     /// Compatibility mask.
     pub compatibility_mask: u32,
     /// VP Index for paging information.
-    /// On X64 these registers include CR3, CR4, RIP and GDTR
-    /// On aarch64 these registers include TTBR0, TCR and PC.
+    /// On X64 these registers include CR3, CR4 and EFER.
+    /// On aarch64 these registers include TCR and TTBR0.
     pub vp_index: u16,
     /// VTL for paging information.
     pub vtl: u8,

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -480,10 +480,13 @@ pub struct TdxPolicy {
 pub const IGVM_VHF_RELOCATABLE_REGION_IS_VTL2: u8 = 0x1;
 /// The starting executable address for the specified VP and VTL should be
 /// adjusted by the amount this region was relocated (RIP on x64, PC on arm64).
-pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_RIP: u8 = 0x2;
+pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_START_ADDRESS: u8 = 0x2;
 /// GDTR for the specified VP and VTL should be adjusted by the amount this
 /// region was relocated. This is supported on X64 only.
 pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_GDTR: u8 = 0x4;
+
+pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_RIP: u8 =
+    IGVM_VHF_RELOCATABLE_REGION_APPLY_START_ADDRESS;
 
 /// Indicate a relocatable region. This region may be relocated according to the
 /// fields within the header. The region must be relocated as a whole, with each
@@ -605,7 +608,9 @@ pub struct IGVM_VHS_RELOCATABLE_REGION {
 pub struct IGVM_VHS_PAGE_TABLE_RELOCATION {
     /// Compatibility mask.
     pub compatibility_mask: u32,
-    /// VP Index for paging information, like the base page register.
+    /// VP Index for paging information.
+    /// On X64 these registers include CR3, CR4, RIP and GDTR
+    /// On aarch64 these registers include TTBR0, TCR and PC.
     pub vp_index: u16,
     /// VTL for paging information.
     pub vtl: u8,

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -480,14 +480,13 @@ pub struct TdxPolicy {
 pub const IGVM_VHF_RELOCATABLE_REGION_IS_VTL2: u8 = 0x1;
 /// The starting executable address for the specified VP and VTL should be
 /// adjusted by the amount this region was relocated (RIP on x64, PC on arm64).
-pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_START_ADDRESS: u8 = 0x2;
+pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_PC: u8 = 0x2;
 /// GDTR for the specified VP and VTL should be adjusted by the amount this
 /// region was relocated. This is supported on X64 only.
 pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_GDTR: u8 = 0x4;
 
-/// Legacy name for ['IGVM_VHF_RELOCATABLE_REGION_APPLY_START_ADDRESS']
-pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_RIP: u8 =
-    IGVM_VHF_RELOCATABLE_REGION_APPLY_START_ADDRESS;
+/// Legacy name for ['IGVM_VHF_RELOCATABLE_REGION_APPLY_PC']
+pub const IGVM_VHF_RELOCATABLE_REGION_APPLY_RIP: u8 = IGVM_VHF_RELOCATABLE_REGION_APPLY_PC;
 
 /// Indicate a relocatable region. This region may be relocated according to the
 /// fields within the header. The region must be relocated as a whole, with each


### PR DESCRIPTION
Add support for aarch64 relocations.

This does not support actually performing the relocations via pagetable fixups, but supports generating IGVM files targeting AArch64 with relocation headers. A future change will add support to the pagetable builder to handle this. 

#58