### PR TITLE
deps: update bitfield-struct and open-enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ igvm_defs = { path = "igvm_defs", version = "0.3.1" }
 igvm = { path = "igvm", version = "0.3.1" }
 
 anyhow = "1.0"
-bitfield-struct = "0.5"
+bitfield-struct = "0.6.2"
 crc32fast = { version = "1.3.2", default-features = false }
 hex = { version = "0.4", default-features = false }
 open-enum = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 bitfield-struct = "0.6.2"
 crc32fast = { version = "1.3.2", default-features = false }
 hex = { version = "0.4", default-features = false }
-open-enum = "0.4.1"
+open-enum = "0.5.1"
 range_map_vec = "0.2.0"
 static_assertions = "1.1"
 thiserror = "1.0"


### PR DESCRIPTION
Update these dependencies to the latest versions from crates.io:
- bitfield-struct to 0.6.2
- open-enum to 0.5.1

This helps reduce duplicates due to different crate versions in the dependency
trees of consuming projects (for example Coconut-SVSM).

