### PR TITLE
igvm_defs: add support for specific purpose memory in MemoryMapEntryType.

### DIFF
--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -1168,14 +1168,14 @@ pub enum MemoryMapEntryType {
     /// applied. Some isolation architectures only allow VTL2 protections on
     /// certain memory ranges.
     VTL2_PROTECTABLE = 0x3,
-    /// Special Purpose memory (SPM). This is memory with special properties
-    /// reserved for application specific purposes and shouldn't be used by
-    /// the firmware or operating system. This corresponds with the UEFI
-    /// memory map entry flag EFI_MEMORY_SP, introduced in UEFI 2.8.
+    /// Specific Purpose memory (SPM). This is memory with special properties
+    /// reserved for specific purposes and shouldn't be used by the firmware
+    /// or operating system. This corresponds with the UEFI memory map entry
+    /// flag EFI_MEMORY_SP, introduced in UEFI 2.8.
     /// See https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html
     #[cfg(feature = "unstable")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-    SPECIAL_PURPOSE = 0x4,
+    SPECIFIC_PURPOSE = 0x4,
 }
 
 impl Default for MemoryMapEntryType {

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -1168,6 +1168,10 @@ pub enum MemoryMapEntryType {
     /// applied. Some isolation architectures only allow VTL2 protections on
     /// certain memory ranges.
     VTL2_PROTECTABLE = 0x3,
+    /// Special Purpose memory (SPM). This is memory with special properties
+    /// reserved for application specific purposes and shouldn't be used by
+    /// the firmware or operating system.
+    SPECIAL_PURPOSE = 0x4,
 }
 
 impl Default for MemoryMapEntryType {

--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -1170,7 +1170,11 @@ pub enum MemoryMapEntryType {
     VTL2_PROTECTABLE = 0x3,
     /// Special Purpose memory (SPM). This is memory with special properties
     /// reserved for application specific purposes and shouldn't be used by
-    /// the firmware or operating system.
+    /// the firmware or operating system. This corresponds with the UEFI
+    /// memory map entry flag EFI_MEMORY_SP, introduced in UEFI 2.8.
+    /// See https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html
+    #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     SPECIAL_PURPOSE = 0x4,
 }
 


### PR DESCRIPTION
This PR adds a MemoryMapEntryType for specific purpose memory. This corresponds with the UEFI memory map attribute EFI_MEMORY_SP, added in UEFI 2.8. EFI_MEMORY_SP is used to indicate that the memory has special properties and is to be reserved for application use, and shouldn't be used by the firmware or OS.