### PR TITLE
deps: update open-enum with fix for cfg derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 bitfield-struct = "0.7"
 crc32fast = { version = "1.3.2", default-features = false }
 hex = { version = "0.4", default-features = false }
-open-enum = "0.5.1"
+open-enum = "0.5.2"
 range_map_vec = "0.2.0"
 static_assertions = "1.1"
 thiserror = "1.0"


### PR DESCRIPTION
Pickup the dependency fix that fixes #63. 