### PR TITLE
igvm_defs: define HIDDEN memory type

### DIFF
--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -1181,6 +1181,11 @@ pub enum MemoryMapEntryType {
     #[cfg(feature = "unstable")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     SPECIFIC_PURPOSE = 0x4,
+    /// Hidden memory is visible in the memory map but is hidden from any other
+    /// enumeration that may be used to expose available memory to the VM.
+    #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    HIDDEN = 0x5,
 }
 
 impl Default for MemoryMapEntryType {


### PR DESCRIPTION
Introduce the HIDDEN memory type to describe memory that is visible only through the IGVM memory map.