### PR TITLE
igvm: remove unused lifetime

### DIFF
--- a/igvm/src/c_api.rs
+++ b/igvm/src/c_api.rs
@@ -86,7 +86,7 @@ struct IgvmFileHandleLock<'a> {
     handle: IgvmHandle,
 }
 
-impl<'a> IgvmFileHandleLock<'a> {
+impl IgvmFileHandleLock<'_> {
     pub fn new(handle: IgvmHandle) -> Result<Self, IgvmResult> {
         let lock = IGVM_HANDLES
             .get()


### PR DESCRIPTION
Clippy suggests removing the needless lifetime.