### PR TITLE
ci: pin toolchain version to 1.86.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: 1.86.0
 
 jobs:
   build:
@@ -20,6 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        components: rustfmt, clippy
     - uses: taiki-e/install-action@nextest
     - name: Format
       run: cargo fmt --all -- --check
@@ -40,6 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Install cbindgen
         run: cargo install cbindgen
       - name: Install build dependencies


### PR DESCRIPTION
Pin the toolchain used in CI to a well known version, so new clippy lints in new versions don't break CI. 

Closes #75 