### PR TITLE
igvm_c/Makefile: Separate build and test target

### DIFF
--- a/igvm_c/Makefile
+++ b/igvm_c/Makefile
@@ -28,7 +28,9 @@ VERSION = $(shell grep -oP "(?<=version = \").+(?=\")" $(IGVM_DIR)/igvm/Cargo.to
 
 .PHONY: install
 
-all: $(API_DIR)/include/igvm.h $(TARGET_PATH)/dump_igvm test
+all: build test
+
+build: $(API_DIR)/include/igvm.h $(TARGET_PATH)/dump_igvm
 
 $(TARGET_PATH)/libigvm.a:
 	$(CARGO) build --features $(FEATURES) $(EXTRA_PARAMS) --manifest-path=$(IGVM_DIR)/igvm/Cargo.toml


### PR DESCRIPTION
Create a new `build` target that is only used to build the static library.
This allows the library to be built without necessarily being tested.

Does not change current behavior as `all` targets both `build` and `test`