### PR TITLE
igvm_c/Makefile: fix path for cross compilation

### DIFF
--- a/igvm_c/Makefile
+++ b/igvm_c/Makefile
@@ -9,9 +9,9 @@ IGVM_DIR := $(API_DIR)/..
 TARGET_DIR ?= target_c
 
 ifdef RELEASE
-TARGET_PATH="$(IGVM_DIR)/$(TARGET_DIR)/release"
+TARGET_PATH="$(IGVM_DIR)/$(TARGET_DIR)/$(CARGO_BUILD_TARGET)/release"
 else
-TARGET_PATH="$(IGVM_DIR)/$(TARGET_DIR)/debug"
+TARGET_PATH="$(IGVM_DIR)/$(TARGET_DIR)/$(CARGO_BUILD_TARGET)/debug"
 endif
 
 PREFIX ?= /usr


### PR DESCRIPTION
When cross-compiling with `CARGO_BUILD_TARGET`, the build output path changes to include the target triple (e.g., `target/<triple>/release/`).

This leads to compilation errors as `TARGET_PATH` does not take that into account.

Update `TARGET_PATH` to include the target triple if set.