### PR TITLE
release: release version 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ members = [
 ]
 
 [workspace.dependencies]
-igvm_defs = { path = "igvm_defs", version = "0.3.4" }
-igvm = { path = "igvm", version = "0.3.4" }
+igvm_defs = { path = "igvm_defs", version = "0.4.0" }
+igvm = { path = "igvm", version = "0.4.0" }
 
 anyhow = "1.0"
 bitfield-struct = "0.10"

--- a/igvm/Cargo.toml
+++ b/igvm/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "igvm"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 description = "The igvm crate is an implementation of a parser for the Independent Guest Virtual Machine (IGVM) file format."
 license = "MIT"

--- a/igvm_defs/Cargo.toml
+++ b/igvm_defs/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "igvm_defs"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 description = "The igvm_defs crate is the specification for the Independent Guest Virtual Machine (IGVM) file format."
 license = "MIT"


### PR DESCRIPTION
Update dependencies (notably zerocopy to 0.8.0).
Pickup various igvm_c fixes and improvements.