### PR TITLE
igvm_c/Makefile: fix installation with empty destdir

### DIFF
--- a/igvm_c/Makefile
+++ b/igvm_c/Makefile
@@ -73,6 +73,6 @@ clean:
 install: build
 	mkdir -p $(DESTDIR)/$(PREFIX)/include/igvm
 	install -m 644 $(IGVM_DIR)/igvm_c/include/* $(DESTDIR)/$(PREFIX)/include/igvm
-	$(CARGO) cinstall --destdir "$(DESTDIR)" --prefix "$(PREFIX)" --features $(FEATURES) $(EXTRA_PARAMS) --manifest-path=$(IGVM_DIR)/igvm/Cargo.toml
+	$(CARGO) cinstall $(if $(DESTDIR), --destdir "$(DESTDIR)") --prefix "$(PREFIX)" --features $(FEATURES) $(EXTRA_PARAMS) --manifest-path=$(IGVM_DIR)/igvm/Cargo.toml
 	mkdir -p $(DESTDIR)/$(PREFIX)/bin/
 	install -m 755 $(TARGET_PATH)/dump_igvm$(EXE) $(DESTDIR)/$(PREFIX)/bin/


### PR DESCRIPTION
"cargo cinstall" does not want --destdir to be empty:

    CARGO_TARGET_DIR=/workspace/igvm/igvm_c/../target_c cargo cinstall --destdir "" --prefix "/usr" --features "igvm-c"  --manifest-path=/workspace/igvm/igvm_c/../igvm/Cargo.toml
    error: a value is required for '--destdir <DESTDIR>' but none was supplied

So, leave it out completely if it is.

Fixes: #96