### PR TITLE
clippy: resolve newer clippy lints for is multiple of checks 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: 1.86.0
+  RUST_TOOLCHAIN: 1.93.0
 
 jobs:
   build:

--- a/igvm/Cargo.toml
+++ b/igvm/Cargo.toml
@@ -5,6 +5,7 @@
 name = "igvm"
 version = "0.4.0"
 edition = "2021"
+rust-version = "1.87"
 description = "The igvm crate is an implementation of a parser for the Independent Guest Virtual Machine (IGVM) file format."
 license = "MIT"
 authors = ["Microsoft"]

--- a/igvm/src/lib.rs
+++ b/igvm/src/lib.rs
@@ -126,7 +126,7 @@ fn append_header<T: IntoBytes + Immutable + KnownLayout>(
     variable_headers.extend_from_slice(header);
     variable_headers.extend(align_up_iter);
 
-    debug_assert!(variable_headers.len() % 8 == 0);
+    debug_assert!(variable_headers.len().is_multiple_of(8));
 }
 
 /// The serializer for headers with file data. This serializer deduplicates data
@@ -1635,7 +1635,7 @@ impl IgvmDirectiveHeader {
                     return Err(BinaryHeaderError::UnalignedAddress(*gpa));
                 }
 
-                if *number_of_bytes as u64 % PAGE_SIZE_4K != 0 {
+                if !(*number_of_bytes as u64).is_multiple_of(PAGE_SIZE_4K) {
                     return Err(BinaryHeaderError::UnalignedSize(*number_of_bytes as u64));
                 }
             }
@@ -2215,7 +2215,7 @@ impl IgvmRelocatableRegion {
         let start = relocation_base;
         let end = relocation_base + self.size;
 
-        if start % self.relocation_alignment != 0 {
+        if !start.is_multiple_of(self.relocation_alignment) {
             tracing::debug!("base is not aligned");
             false
         } else if start < self.minimum_relocation_gpa {


### PR DESCRIPTION
Cleanup manual is multiple of checks that are flagged by newer versions of clippy. 

Update the rust version used in CI to latest stable. Also update the MSRV to 1.87 for the igvm crate where this function was stabilized. This means the next update will need to be a major version update. 