### PR TITLE
igvm: Update SevVmsa structure definition. Pad to full 4K.

### DIFF
--- a/igvm/src/lib.rs
+++ b/igvm/src/lib.rs
@@ -1860,14 +1860,10 @@ impl IgvmDirectiveHeader {
                             .and_then(|x| x.get(..PAGE_SIZE_4K as usize))
                             .ok_or(BinaryHeaderError::InvalidDataSize)?;
 
-                        // Copy the VMSA bytes into the VMSA, and validate the remaining bytes are 0.
+                        // Copy the VMSA bytes into the VMSA.
                         // todo: zerocopy: as of 0.8, can recover from allocation failure
                         let mut vmsa = SevVmsa::new_box_zeroed().unwrap();
-                        let (vmsa_slice, remaining) = data.split_at(size_of::<SevVmsa>());
-                        vmsa.as_mut_bytes().copy_from_slice(vmsa_slice);
-                        if remaining.iter().any(|b| *b != 0) {
-                            return Err(BinaryHeaderError::InvalidVmsa);
-                        }
+                        vmsa.as_mut_bytes().copy_from_slice(data);
 
                         IgvmDirectiveHeader::SnpVpContext {
                             gpa: header.gpa.into(),

--- a/igvm/src/snp_defs.rs
+++ b/igvm/src/snp_defs.rs
@@ -324,4 +324,7 @@ pub struct SevVmsa {
 
     // YMM high registers
     pub ymm_registers: [SevXmmRegister; 16],
+
+    // Pad to 4KB
+    pub vmsa_padding: [u8; 2448],
 }


### PR DESCRIPTION
Fixes #108 - Updates SevVmsa with documented VMSA fields and extends structure to 4K page size.