### PR TITLE
docs: Remove version restriction on IgvmNativeVpContextX64

### DIFF
--- a/igvm_defs/src/lib.rs
+++ b/igvm_defs/src/lib.rs
@@ -886,8 +886,6 @@ pub struct IGVM_VHS_ERROR_RANGE {
 /// initial context, such as AMD SEV.
 /// Registers not specified here are initialized to their architectural
 /// reset values.
-///
-/// Only supported in version 2 and later files.
 #[cfg(feature = "unstable")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[repr(C)]


### PR DESCRIPTION
The documentation mentions a file format version restriction for `IgvmNativeVpContextX64`. However, neither the generator nor the parser enforce this: they will happily generate/parse IGVM files with a `IGVM_VHT_VP_CONTEXT` header when the revision is 1 and the platform type is NATIVE. QEMU will happily launch such IGVMs correctly. As such, this entire restriction seems to be meaningless.