### PR TITLE
Minimize the dependencies introduced by corim feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ igvm = { path = "igvm", version = "0.4.0" }
 
 anyhow = "1.0"
 bitfield-struct = "0.12"
-corim = "0.1.2"
+corim = { version = "0.1.2", default-features = false }
 crc32fast = { version = "1.3.2", default-features = false }
 hex = { version = "0.4", default-features = false }
 open-enum = "0.5.2"
 range_map_vec = "0.2.0"
-sha2 = "0.10"
+sha2 = { version = "0.10", default-features = false }
 static_assertions = "1.1"
 thiserror = "2.0"
 tracing = "0.1"
-uuid = { version = "1", features = ["v5"] }
+uuid = { version = "1", default-features = false, features = ["v5"] }
 zerocopy = { version = "0.8.14", features = ["derive"] }

--- a/igvm/src/corim/launch_measurement/builder.rs
+++ b/igvm/src/corim/launch_measurement/builder.rs
@@ -155,7 +155,7 @@ mod tests {
         let svn = le.triples()[0].svn();
 
         let bytes = super::build_corim_bytes(platform, &measurement, svn).unwrap();
-        corim::validate::decode_and_validate(&bytes).unwrap()
+        corim::validate::decode_and_validate_at(&bytes, 0).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Use default-features = false for newly introduced dependencies in corim feature